### PR TITLE
Fix missing code for Ignore_unauthorized

### DIFF
--- a/lib/POE/Component/IRC/Plugin/BotCommand.pm
+++ b/lib/POE/Component/IRC/Plugin/BotCommand.pm
@@ -177,8 +177,10 @@ sub _handle_cmd {
             my @errors = ref $errors eq 'ARRAY'
                 ? @$errors
                 : 'You are not authorized to use this command.';
-            for my $error (@errors) {
-                $irc->yield($self->{Method}, $where, $error);
+            if (!$self->{Ignore_unauthorized}) {
+                for my $error (@errors) {
+                    $irc->yield($self->{Method}, $where, $error);
+                }
             }
             return;
         }


### PR DESCRIPTION
As far as I can tell the documented Ignore_unauthorized parameter in the BotCommand plugin is completely non-functional.

> 'Ignore_unauthorized', if true, the plugin will ignore unauthorized commands, rather than printing an error message upon receiving them. This is only relevant if 'Auth_sub' is also supplied. Default is false.

I have made a tiny change which seems to work as I expect.

Thank you!
Chris Roberts
