### PR TITLE
Add support for WEBIRC.

### DIFF
--- a/lib/POE/Component/IRC.pm
+++ b/lib/POE/Component/IRC.pm
@@ -479,6 +479,13 @@ sub _send_login {
     $kernel->call($session, 'sl_login', 'CAP LS');
     $kernel->call($session, 'sl_login', 'CAP END');
 
+    # If we were told to use WEBIRC to spoof our host/IP, do so:
+    if (defined $self->{webirc}) {
+        $kernel->call($session => sl_login => 'WEBIRC '
+            . join " ", @{$self->{webirc}}{qw(pass user ip host)}
+        );
+    }
+
     if (defined $self->{password}) {
         $kernel->call($session => sl_login => 'PASS ' . $self->{password});
     }
@@ -1789,6 +1796,12 @@ specified.
 =item * B<'socks_id'>, specify a SOCKS user_id. Default is none.
 
 =item * B<'useipv6'>, enable the use of IPv6 for connections.
+
+=item * B<'webirc'>, enable the use of WEBIRC to spoof host/IP.
+You must have a WEBIRC password set up on the IRC server/network (so will
+only work for servers which trust you to spoof the IP & host the connection
+is from) - value should be a hashref containing keys C<pass>, C<user>,
+C<host> and C<ip>.
 
 =back
 

--- a/lib/POE/Component/IRC.pm
+++ b/lib/POE/Component/IRC.pm
@@ -213,6 +213,17 @@ sub _configure {
         $self->{server} = $ENV{IRCSERVER};
     }
 
+    if (defined $self->{webirc}) {
+        if (!ref $self->{webirc} ne 'HASH') {
+            die "webirc param expects a hashref";
+        }
+        for my $expect_key (qw(pass user host ip)) {
+            if (!exists $self->{webirc}{$expect_key}) {
+                die "webirc value is missing key '$expect_key'";
+            }
+        }
+    }
+
     return;
 }
 


### PR DESCRIPTION
Allows you to provide a `webirc` param, containing a hashref of details to use
in a WEBIRC command to spoof the connecting user's IP and host - not of use to
many people, but very helpful if you're working on a web IRC gateway or
something else that needs to be able to spoof where the connection is from.

Obviously useless unless the server/network you're connecting to trusts you
enough to configure WEBIRC for you, so the target audience for this feature is
fairly small :)
