### PR TITLE
Don't queue messages if $self->{flood}

### DIFF
--- a/lib/POE/Component/IRC.pm
+++ b/lib/POE/Component/IRC.pm
@@ -1089,7 +1089,7 @@ sub sl_prioritized {
         $msg = bytes::substr($msg, 0, $self->{msg_length} - bytes::length($self->nick_name()));
     }
 
-    if (@{ $self->{send_queue} }) {
+    if (!$self->{flood} && @{ $self->{send_queue} }) {
         my $i = @{ $self->{send_queue} };
         $i-- while ($i && $priority < $self->{send_queue}->[$i-1]->[MSG_PRI]);
         splice( @{ $self->{send_queue} }, $i, 0, [ $priority, $msg ] );


### PR DESCRIPTION
I think this should fix #10.

If `$self->{flood}` is set, then just send the message - even if there
is currently a queue (because e.g. we wanted to send stuff while we were
disconnected, so queued it).

Otherwise, for a reasonably chatty bot, once it has disconnected once,
and one or more messages got queued in the meantime, all future messages
will go into the queue too, ignoring `$self->{flood}` - and that will
remain until such time as the queue manages to empty, which for a chatty
bot might not happen.
